### PR TITLE
Pre-compute contract deployment address

### DIFF
--- a/examples/PreCompute.sol
+++ b/examples/PreCompute.sol
@@ -1,0 +1,26 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.0;
+
+contract PreCompute {
+    // pre-compute by EOA and its nonce
+    function addressFrom(address _deployer, uint _nonce) external pure returns (address _address) {
+        bytes memory data;
+        if(_nonce == 0x00)
+            data = abi.encodePacked(bytes1(0xd6), bytes1(0x94), _deployer, bytes1(0x80));
+        else if(_nonce <= 0x7f)
+            data = abi.encodePacked(bytes1(0xd6), bytes1(0x94), _deployer, uint8(_nonce));
+        else if(_nonce <= 0xff)
+            data = abi.encodePacked(bytes1(0xd7), bytes1(0x94), _deployer, bytes1(0x81), uint8(_nonce));
+        else if(_nonce <= 0xffff)
+            data = abi.encodePacked(bytes1(0xd8), bytes1(0x94), _deployer, bytes1(0x82), uint16(_nonce));
+        else if(_nonce <= 0xffffff)
+            data = abi.encodePacked(bytes1(0xd9), bytes1(0x94), _deployer, bytes1(0x83), uint24(_nonce));
+        else
+            data = abi.encodePacked(bytes1(0xda), bytes1(0x94), _deployer, bytes1(0x84), uint32(_nonce));
+        bytes32 hash = keccak256(data);
+        assembly {
+            mstore(0, hash)
+            _address := mload(0)
+        }
+    }
+}


### PR DESCRIPTION
Some may not be familiar with CREATE or CREATE2 feature of the EIPs, so this pre-compute contract may help them deploy GMP-based contracts on Remix, even if they don't use Foundry.